### PR TITLE
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/recentimages/src/main/java/com/amirarcane/recentimages/thumbnailOptions/ImageAdapter.java
+++ b/recentimages/src/main/java/com/amirarcane/recentimages/thumbnailOptions/ImageAdapter.java
@@ -287,13 +287,6 @@ public class ImageAdapter extends CursorAdapter {
 		private final PoolWorker[] mThreads;
 		protected final LinkedList<ImageLoader> mQueue;
 
-		public static synchronized WorkQueue getInstance() {
-			if (sInstance == null) {
-				sInstance = new WorkQueue(NUM_OF_THREADS);
-			}
-			return sInstance;
-		}
-
 		private WorkQueue(int nThreads) {
 			mNumOfThreads = nThreads;
 			mQueue = new LinkedList<ImageLoader>();
@@ -303,6 +296,13 @@ public class ImageAdapter extends CursorAdapter {
 				mThreads[i] = new PoolWorker();
 				mThreads[i].start();
 			}
+		}
+
+		public static synchronized WorkQueue getInstance() {
+			if (sInstance == null) {
+				sInstance = new WorkQueue(NUM_OF_THREADS);
+			}
+			return sInstance;
 		}
 
 		public void execute(ImageLoader r) {

--- a/recentimages/src/main/java/com/jess/ui/TwoWayAbsListView.java
+++ b/recentimages/src/main/java/com/jess/ui/TwoWayAbsListView.java
@@ -853,6 +853,17 @@ ViewTreeObserver.OnTouchModeChangeListener {
 	}
 
 	static class SavedState extends BaseSavedState {
+		public static final Parcelable.Creator<SavedState> CREATOR
+				= new Parcelable.Creator<SavedState>() {
+			public SavedState createFromParcel(Parcel in) {
+				return new SavedState(in);
+			}
+
+			public SavedState[] newArray(int size) {
+				return new SavedState[size];
+			}
+		};
+
 		long selectedId;
 		long firstId;
 		int viewTop;
@@ -902,17 +913,6 @@ ViewTreeObserver.OnTouchModeChangeListener {
 			+ " height=" + height + "}";
 			//+ " filter=" + filter + "}";
 		}
-
-		public static final Parcelable.Creator<SavedState> CREATOR
-		= new Parcelable.Creator<SavedState>() {
-			public SavedState createFromParcel(Parcel in) {
-				return new SavedState(in);
-			}
-
-			public SavedState[] newArray(int size) {
-				return new SavedState[size];
-			}
-		};
 	}
 
 	@Override
@@ -3678,17 +3678,16 @@ ViewTreeObserver.OnTouchModeChangeListener {
 			protected final Scroller mScroller;
 
 			protected Runnable mCheckFlywheel;
-			
+
+			FlingRunnable() {
+				mScroller = new Scroller(getContext());
+			}
+
 			public boolean isScrollingInDirection(float xvel, float yvel) {
 				final int dx = mScroller.getFinalX() - mScroller.getStartX();
 				final int dy = mScroller.getFinalY() - mScroller.getStartY();
 				return !mScroller.isFinished() && Math.signum(xvel) == Math.signum(dx) &&
 						Math.signum(yvel) == Math.signum(dy);
-			}
-
-
-			FlingRunnable() {
-				mScroller = new Scroller(getContext());
 			}
 
 			abstract void flywheelTouch();
@@ -4469,6 +4468,7 @@ ViewTreeObserver.OnTouchModeChangeListener {
 		 *
 		 */
 		private class VerticalFlingRunnable extends FlingRunnable {
+			private static final int FLYWHEEL_TIMEOUT = 40; // milliseconds
 			/**
 			 * Y value reported by mScroller on the previous fling
 			 */
@@ -4562,8 +4562,6 @@ ViewTreeObserver.OnTouchModeChangeListener {
 				}
 
 			}
-			
-			private static final int FLYWHEEL_TIMEOUT = 40; // milliseconds
 			
 			public void flywheelTouch() {
 				if(mCheckFlywheel == null) {
@@ -5354,6 +5352,7 @@ ViewTreeObserver.OnTouchModeChangeListener {
 		 *
 		 */
 		private class HorizontalFlingRunnable extends FlingRunnable {
+			private static final int FLYWHEEL_TIMEOUT = 40; // milliseconds
 			/**
 			 * X value reported by mScroller on the previous fling
 			 */
@@ -5448,9 +5447,6 @@ ViewTreeObserver.OnTouchModeChangeListener {
 
 			}
 			
-			
-			private static final int FLYWHEEL_TIMEOUT = 40; // milliseconds
-	
 			public void flywheelTouch() {
 				if(mCheckFlywheel == null) {
 					mCheckFlywheel = new Runnable() {

--- a/recentimages/src/main/java/com/jess/ui/TwoWayAdapterView.java
+++ b/recentimages/src/main/java/com/jess/ui/TwoWayAdapterView.java
@@ -417,12 +417,6 @@ public abstract class TwoWayAdapterView<T extends Adapter> extends ViewGroup {
 	 */
 	public static class AdapterContextMenuInfo implements ContextMenu.ContextMenuInfo {
 
-		public AdapterContextMenuInfo(View targetView, int position, long id) {
-			this.targetView = targetView;
-			this.position = position;
-			this.id = id;
-		}
-
 		/**
 		 * The child view for which the context menu is being displayed. This
 		 * will be one of the children of this AdapterView.
@@ -439,6 +433,12 @@ public abstract class TwoWayAdapterView<T extends Adapter> extends ViewGroup {
 		 * The row id of the item for which the context menu is being displayed.
 		 */
 		public long id;
+
+		public AdapterContextMenuInfo(View targetView, int position, long id) {
+			this.targetView = targetView;
+			this.position = position;
+			this.id = id;
+		}
 	}
 
 	/**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
This pull request removes 40 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava
