### PR TITLE
squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause

### DIFF
--- a/recentimages/src/main/java/com/jess/ui/TwoWayAbsListView.java
+++ b/recentimages/src/main/java/com/jess/ui/TwoWayAbsListView.java
@@ -3968,6 +3968,8 @@ ViewTreeObserver.OnTouchModeChangeListener {
 						mLastY = y;
 					}
 					break;
+				default:
+					break;
 				}
 
 				break;
@@ -4067,6 +4069,8 @@ ViewTreeObserver.OnTouchModeChangeListener {
 						reportScrollStateChange(OnScrollListener.SCROLL_STATE_IDLE);
 					}
 					break;
+				default:
+					break;
 				}
 
 				setPressed(false);
@@ -4115,6 +4119,8 @@ ViewTreeObserver.OnTouchModeChangeListener {
 				mActivePointerId = INVALID_POINTER;
 				break;
 			}
+			default:
+				break;
 
 			}
 
@@ -4182,6 +4188,8 @@ ViewTreeObserver.OnTouchModeChangeListener {
 					reportScrollStateChange(OnScrollListener.SCROLL_STATE_IDLE);
 					break;
 				}
+				default:
+					break;
 			}
 
 			return false;
@@ -4809,6 +4817,9 @@ ViewTreeObserver.OnTouchModeChangeListener {
 					break;
 				}
 
+				default:
+					break;
+
 			}
 
 			return false;
@@ -4933,6 +4944,8 @@ ViewTreeObserver.OnTouchModeChangeListener {
 							mLastX = x;
 						}
 						break;
+					default:
+						break;
 					}
 	
 					break;
@@ -5032,6 +5045,8 @@ ViewTreeObserver.OnTouchModeChangeListener {
 							reportScrollStateChange(OnScrollListener.SCROLL_STATE_IDLE);
 						}
 						break;
+					default:
+						break;
 					}
 	
 					setPressed(false);
@@ -5080,6 +5095,9 @@ ViewTreeObserver.OnTouchModeChangeListener {
 					mActivePointerId = INVALID_POINTER;
 					break;
 				}
+
+				default:
+					break;
 			}
 
 			return true;

--- a/recentimages/src/main/java/com/jess/ui/TwoWayGridView.java
+++ b/recentimages/src/main/java/com/jess/ui/TwoWayGridView.java
@@ -414,6 +414,8 @@ public class TwoWayGridView extends TwoWayAbsListView {
 				case KeyEvent.KEYCODE_ENTER:
 					resurrectSelection();
 					return true;
+				default:
+					break;
 				}
 			}
 
@@ -468,6 +470,8 @@ public class TwoWayGridView extends TwoWayAbsListView {
 					handled = pageScroll(FOCUS_UP);
 				}
 				//}
+				break;
+			default:
 				break;
 			}
 		}
@@ -1494,6 +1498,8 @@ public class TwoWayGridView extends TwoWayAbsListView {
 						mHorizontalSpacing = ((requestedHorizontalSpacing * 2) + spaceLeftOver) / 2;
 					}
 					break;
+				default:
+					break;
 				}
 
 				break;
@@ -2081,6 +2087,8 @@ public class TwoWayGridView extends TwoWayAbsListView {
 					setSelectionInt(Math.min(selectedPosition + 1, mItemCount - 1));
 					moved = true;
 				}
+				break;
+			default:
 				break;
 			}
 
@@ -2992,6 +3000,9 @@ public class TwoWayGridView extends TwoWayAbsListView {
 						mVerticalSpacing = ((requestedVerticalSpacing * 2) + spaceLeftOver) / 2;
 					}
 					break;
+
+				default:
+					break;
 				}
 
 				break;
@@ -3403,6 +3414,8 @@ public class TwoWayGridView extends TwoWayAbsListView {
 					setSelectionInt(Math.min(selectedPosition + 1, mItemCount - 1));
 					moved = true;
 				}
+				break;
+			default:
 				break;
 			}
 

--- a/sample/src/main/java/com/amirarcane/sample/MainActivity.java
+++ b/sample/src/main/java/com/amirarcane/sample/MainActivity.java
@@ -121,6 +121,8 @@ public class MainActivity extends AppCompatActivity {
 					imageUri = data.getData();
 				}
 				break;
+			default:
+				break;
 		}
 		Bitmap bitmap = null;
 		try {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause.
This pull request removes 75 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:SwitchLastCaseIsDefaultCheck
Please let me know if you have any questions.
George Kankava
