### PR TITLE
Multiple code improvements - squid:S1068, squid:S1148, squid:S1488

### DIFF
--- a/recentimages/src/main/java/com/amirarcane/recentimages/RecentImages.java
+++ b/recentimages/src/main/java/com/amirarcane/recentimages/RecentImages.java
@@ -3,6 +3,7 @@ package com.amirarcane.recentimages;
 import android.content.Context;
 import android.database.Cursor;
 import android.provider.MediaStore;
+import android.util.Log;
 
 import com.amirarcane.recentimages.thumbnailOptions.ImageAdapter;
 
@@ -10,6 +11,8 @@ import com.amirarcane.recentimages.thumbnailOptions.ImageAdapter;
  * Created by Arcane on 10/30/15 AD.
  */
 public class RecentImages {
+
+	private static final String TAG = "RecentImages";
 
 	public static final String ASCENDING = " ASC";
 	public static final String DESCENDING = " DESC";
@@ -35,10 +38,9 @@ public class RecentImages {
 					MediaStore.Images.ImageColumns.BUCKET_DISPLAY_NAME, MediaStore.Images.ImageColumns.DATE_TAKEN, MediaStore.Images.ImageColumns.MIME_TYPE};
 			mImageCursor = context.getContentResolver().query(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, projection, null, null, columns + sort);
 		} catch (Exception e) {
-			e.printStackTrace();
+			Log.e(TAG, "Exception while getting adapter", e);
 		}
-		ImageAdapter mAdapter = new ImageAdapter(context, mImageCursor);
-		return mAdapter;
+		return new ImageAdapter(context, mImageCursor);
 	}
 
 	public void setDrawable(int drawable) {

--- a/recentimages/src/main/java/com/amirarcane/recentimages/thumbnailOptions/ReplaceableBitmapDrawable.java
+++ b/recentimages/src/main/java/com/amirarcane/recentimages/thumbnailOptions/ReplaceableBitmapDrawable.java
@@ -28,8 +28,6 @@ import android.graphics.drawable.Drawable;
 import android.view.Gravity;
 
 public class ReplaceableBitmapDrawable extends Drawable {
-	private static final String TAG = "ReplaceableBitmapDrawable";
-	private static final boolean DEBUG = false;
 
 	private Bitmap mBitmap;
 	private boolean mLoaded;

--- a/recentimages/src/main/java/com/jess/ui/TwoWayAbsListView.java
+++ b/recentimages/src/main/java/com/jess/ui/TwoWayAbsListView.java
@@ -448,7 +448,6 @@ ViewTreeObserver.OnTouchModeChangeListener {
 	//private boolean mGlobalLayoutListenerAddedFilter;
 
 	private int mTouchSlop;
-	private float mDensityScale;
 
 	//private InputConnection mDefInputConnection;
 	//private InputConnectionWrapper mPublicInputConnection;
@@ -470,12 +469,6 @@ ViewTreeObserver.OnTouchModeChangeListener {
 	// True when the popup should be hidden because of a call to
 	// dispatchDisplayHint()
 	//private boolean mPopupHidden;
-
-	/**
-	 * ID of the active pointer. This is used to retain consistency during
-	 * drags/flings if multiple pointers are used.
-	 */
-	private int mActivePointerId = INVALID_POINTER;
 
 	/**
 	 * Sentinel value for no current active pointer.

--- a/sample/src/main/java/com/amirarcane/sample/MainActivity.java
+++ b/sample/src/main/java/com/amirarcane/sample/MainActivity.java
@@ -12,6 +12,7 @@ import android.provider.MediaStore;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
+import android.util.Log;
 import android.view.Gravity;
 import android.view.View;
 import android.widget.Button;
@@ -29,12 +30,14 @@ import java.util.ArrayList;
 
 public class MainActivity extends AppCompatActivity {
 
+	private static final String TAG = "MainActivity";
+
 	private Uri imageUri;
 	ArrayList<MenuItem> menuItems = new ArrayList<>();
-	private TwoWayGridView mImageGrid;
-	private ImageView image;
 
+	private ImageView image;
 	private static final int TAKE_PICTURE = 0;
+
 	private static final int SELECT_PHOTO = 1;
 
 	@Override
@@ -99,7 +102,7 @@ public class MainActivity extends AppCompatActivity {
 						try {
 							bitmap = MediaStore.Images.Media.getBitmap(MainActivity.this.getContentResolver(), imageUri);
 						} catch (IOException e) {
-							e.printStackTrace();
+							Log.e(TAG, "Exception while getting image", e);
 						}
 						image.setImageBitmap(bitmap);
 					}
@@ -126,7 +129,7 @@ public class MainActivity extends AppCompatActivity {
 		try {
 			bitmap = MediaStore.Images.Media.getBitmap(MainActivity.this.getContentResolver(), imageUri);
 		} catch (IOException e) {
-			e.printStackTrace();
+			Log.e(TAG, "Exception while getting image", e);
 		}
 		image.setImageBitmap(bitmap);
 	}

--- a/sample/src/main/java/com/amirarcane/sample/RecyclerItemClickListener.java
+++ b/sample/src/main/java/com/amirarcane/sample/RecyclerItemClickListener.java
@@ -7,7 +7,6 @@ import android.view.MotionEvent;
 import android.view.View;
 
 public class RecyclerItemClickListener implements RecyclerView.OnItemTouchListener {
-	private static final String TAG = "RecyclerItemClickListe";
 	private OnItemClickListener mListener;
 	private GestureDetector mGestureDetector;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1068 - Unused private fields should be removed.
squid:S1148 - Throwable.printStackTrace(...) should not be called.
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown.
This pull request removes 40 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1068
https://dev.eclipse.org/sonar/rules/show/squid:S1148
https://dev.eclipse.org/sonar/rules/show/squid:S1488
Please let me know if you have any questions.
George Kankava
