### PR TITLE
Multiple code improvements - squid:S1854, squid:S2386, squid:S1481

### DIFF
--- a/recentimages/src/main/java/com/amirarcane/recentimages/thumbnailOptions/ImageAdapter.java
+++ b/recentimages/src/main/java/com/amirarcane/recentimages/thumbnailOptions/ImageAdapter.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class ImageAdapter extends CursorAdapter {
-	public static final String[] IMAGE_PROJECTION = {
+	private static final String[] IMAGE_PROJECTION = {
 			MediaStore.Images.ImageColumns._ID,
 			MediaStore.Images.ImageColumns.DISPLAY_NAME,
 	};
@@ -327,6 +327,7 @@ public class ImageAdapter extends CursorAdapter {
 							try {
 								mQueue.wait();
 							} catch (InterruptedException ignored) {
+								Thread.currentThread().interrupt();
 							}
 						}
 

--- a/recentimages/src/main/java/com/jess/ui/TwoWayAbsListView.java
+++ b/recentimages/src/main/java/com/jess/ui/TwoWayAbsListView.java
@@ -2976,8 +2976,6 @@ ViewTreeObserver.OnTouchModeChangeListener {
 	protected boolean checkConsistency(int consistency) {
 		boolean result = true;
 
-		final boolean checkLayout = true;
-
 		// The active recycler must be empty
 		final View[] activeViews = mRecycler.mActiveViews;
 		int count = activeViews.length;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1854 - Dead stores should be removed.
squid:S2386 - Mutable fields should not be "public static".
squid:S1481 - Unused local variables should be removed.
This pull request removes 50 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:S2386
https://dev.eclipse.org/sonar/rules/show/squid:S1481
Please let me know if you have any questions.
George Kankava
